### PR TITLE
Mount volume options optional fields

### DIFF
--- a/src/docr/types/mount.cr
+++ b/src/docr/types/mount.cr
@@ -34,7 +34,7 @@ module Docr::Types
     property no_copy : Bool = false
 
     @[JSON::Field(key: "Labels")]
-    property labels : Hash(String, String)
+    property labels : Hash(String, String)?
 
     @[JSON::Field(key: "DriverConfig")]
     property driver_config : Docr::Types::DriverConfig

--- a/src/docr/types/mount.cr
+++ b/src/docr/types/mount.cr
@@ -37,7 +37,7 @@ module Docr::Types
     property labels : Hash(String, String)?
 
     @[JSON::Field(key: "DriverConfig")]
-    property driver_config : Docr::Types::DriverConfig
+    property driver_config : Docr::Types::DriverConfig?
   end
 
   class TmpfsOptions


### PR DESCRIPTION
Several fields under Mount > VolumeOptions need to be optional (they're not being returned on Docker version 25.0.2, build 29cf629 (Docker Desktop for Mac).

Thanks for a great project!