### PR TITLE
FIx JSON parse error when the docker engine returns null for "Ports"

### DIFF
--- a/src/docr/types/container_summary.cr
+++ b/src/docr/types/container_summary.cr
@@ -23,7 +23,7 @@ module Docr::Types
     property created : Int64
 
     @[JSON::Field(key: "Ports")]
-    property ports : Array(Port)
+    property ports = [] of Port
 
     @[JSON::Field(key: "SizeRw")]
     property size_rw : Int64?
@@ -41,7 +41,7 @@ module Docr::Types
     property status : String
 
     @[JSON::Field(key: "Mounts")]
-    property mounts : Array(Docr::Types::Mount)
+    property mounts = [] of Docr::Types::Mount
   end
 end
 


### PR DESCRIPTION
Haven't seen this behavior for mounts but changed it too just in case...

Here's what the engine returned on Docker Desktop for Mac 4.45.0 (203075) for one container (the rest were fine):
```
{
    "Id": "9d66904f40379fdc54cc552646ddef309804019e021155a5776b51df92c1fae4",
    "Names": [
      "/aureax-nd0bhmmkph-aureax-agent-1"
    ],
    "Image": "aureax:development",
    "ImageID": "sha256:80931a25d1cf89bad6fe8800c27d108a1cfb558f2b9709fc848a44323d5ff2b7",
    "Command": "tini -- crystal bin/development_agent.cr",
    "Created": 1757614189,
    "Ports": null,
    "Labels": {
      "aureax.cluster.id": "cls0hkt549r",
      "aureax.node.id": "nd0bhmmkph",
  ```